### PR TITLE
修改 isEnabled() 方法中 enabled 为 enable

### DIFF
--- a/src/Config/DomainConfig.php
+++ b/src/Config/DomainConfig.php
@@ -37,7 +37,7 @@ class DomainConfig
 
     public function isEnabled(): bool
     {
-        return $this->config->get('gotask.enabled', false);
+        return $this->config->get('gotask.enable', false);
     }
 
     public function getAddress(): string

--- a/src/Config/DomainConfig.php
+++ b/src/Config/DomainConfig.php
@@ -37,7 +37,7 @@ class DomainConfig
 
     public function isEnabled(): bool
     {
-        return $this->config->get('gotask.enable', false);
+        return $this->config->get('gotask.enable', false) || $this->config->get('gotask.enabled', false);
     }
 
     public function getAddress(): string


### PR DESCRIPTION
gotaks.php 配置文件中的 enable 与当前文件的 enabled 不一致导致 GoTask 进程无法启动